### PR TITLE
feat: remove WebP support check in load func

### DIFF
--- a/.changeset/dirty-moles-wait.md
+++ b/.changeset/dirty-moles-wait.md
@@ -1,0 +1,5 @@
+---
+"@fepack/image": patch
+---
+
+feat: remove WebP support check in load func

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,10 +3,10 @@ coverage:
     project:
       default:
         target: 100%
-        threshold: 60%
+        threshold: 100%
       fepack-image:
         target: 100%
-        threshold: 60%
+        threshold: 100%
 
 comment:
   layout: "header, reach, diff, flags, components"

--- a/packages/image/src/load.ts
+++ b/packages/image/src/load.ts
@@ -1,22 +1,16 @@
-import checkWebPSupport from "./checkWebPSupport";
-
 interface ImageSource {
   defaultSrc: string;
   webpSrc?: string;
 }
 
 /**
- * Loads the given images. If WebP is supported and a WebP source is provided, it will load that. Otherwise, it loads the default source.
+ * Loads the given images. If WebP is WebP source is provided, it will load that. Otherwise, it loads the default source.
  * @param {ImageSource[]} images - Array of image sources to preload.
  */
-async function load(images: ImageSource[]) {
-  const webpSupported = await checkWebPSupport();
-
+function load(images: ImageSource[]) {
   for (const image of images) {
-    const selectedSource =
-      webpSupported && image.webpSrc ? image.webpSrc : image.defaultSrc;
     const imageElement = new Image();
-    imageElement.src = selectedSource;
+    imageElement.src = image.webpSrc ? image.webpSrc : image.defaultSrc;
   }
 }
 


### PR DESCRIPTION
## Summary

<!-- Please summarize your changes. -->

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

Removed the WebP support check in the load function. The rationale is that the load function should only be responsible for loading images. This change was decided upon after an in-depth discussion with @manudeli . Shoutout to @manudeli 

## Checks

<!-- For completed items, change [ ] to [x]. -->

<!-- If you leave this checklist empty, your PR will very likely be closed. -->

Please check the following:

- [x] I have written documents and tests, if needed.
