### PR TITLE
feat: utility for MIME type detection (detect func)

### DIFF
--- a/.changeset/stale-bulldogs-report.md
+++ b/.changeset/stale-bulldogs-report.md
@@ -1,0 +1,5 @@
+---
+"@fepack/image": patch
+---
+
+feat: utility for MIME type detection (detect func)

--- a/.changeset/sweet-gifts-grow.md
+++ b/.changeset/sweet-gifts-grow.md
@@ -1,0 +1,5 @@
+---
+"@fepack/image": patch
+---
+
+feat: utility for MIME type detection (detect func)

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -49,6 +49,7 @@
     "@fepack/eslint-config-js": "workspace:*",
     "@fepack/eslint-config-ts": "workspace:*",
     "@fepack/tsconfig": "workspace:*",
+    "@types/node": "^20.6.2",
     "@vitest/browser": "^0.34.4",
     "@vitest/coverage-istanbul": "^0.34.4",
     "esbuild": "^0.18.11",

--- a/packages/image/src/__test__/detect.test.ts
+++ b/packages/image/src/__test__/detect.test.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "buffer";
 import { describe, expect, test } from "vitest";
 import { detect } from "..";
-import { FILE_SIGNATURES, MIME_TYPES, type MimeType } from "../detect";
+import { FILE_TYPES } from "../detect";
 
 describe("MIME type detection utility", () => {
   test("should return null for unknown signatures", () => {
@@ -9,12 +9,13 @@ describe("MIME type detection utility", () => {
     expect(detect(unknownSignature)).toBeNull();
   });
 
-  Object.keys(FILE_SIGNATURES).forEach((key) => {
-    const mimeType = key as MimeType;
+  Object.keys(FILE_TYPES).forEach((key) => {
+    const mimeType = FILE_TYPES[key].mime;
+    const signature = FILE_TYPES[key].signature;
 
-    test(`should detect ${mimeType} files`, () => {
-      const signatureBuffer = Buffer.from(FILE_SIGNATURES[mimeType]);
-      expect(detect(signatureBuffer)).toEqual(MIME_TYPES[mimeType]);
+    test(`should detect ${key} files`, () => {
+      const signatureBuffer = Buffer.from(signature);
+      expect(detect(signatureBuffer)).toEqual(mimeType);
     });
   });
 
@@ -25,9 +26,9 @@ describe("MIME type detection utility", () => {
 
   test("should detect MIME type even with extra data", () => {
     const jpegWithExtraData = Buffer.concat([
-      Buffer.from(FILE_SIGNATURES.JPEG),
+      Buffer.from(FILE_TYPES.JPEG.signature),
       Buffer.from([0x00, 0x01, 0x02]),
     ]);
-    expect(detect(jpegWithExtraData)).toEqual(MIME_TYPES.JPEG);
+    expect(detect(jpegWithExtraData)).toEqual(FILE_TYPES.JPEG.mime);
   });
 });

--- a/packages/image/src/__test__/detect.test.ts
+++ b/packages/image/src/__test__/detect.test.ts
@@ -10,12 +10,11 @@ describe("MIME type detection utility", () => {
   });
 
   Object.keys(FILE_TYPES).forEach((key) => {
-    const mimeType = FILE_TYPES[key].mime;
-    const signature = FILE_TYPES[key].signature;
+    const { mime, signature } = FILE_TYPES[key];
 
     test(`should detect ${key} files`, () => {
       const signatureBuffer = Buffer.from(signature);
-      expect(detect(signatureBuffer)).toEqual(mimeType);
+      expect(detect(signatureBuffer)).toEqual(mime);
     });
   });
 

--- a/packages/image/src/__test__/detect.test.ts
+++ b/packages/image/src/__test__/detect.test.ts
@@ -1,0 +1,32 @@
+import { Buffer } from "buffer";
+import { describe, expect, test } from "vitest";
+import { FILE_SIGNATURES, MIME_TYPES, type MimeType, detect } from "..";
+
+describe("MIME type detection utility", () => {
+  test("should return null for unknown signatures", () => {
+    const unknownSignature = Buffer.from([0x00, 0x00, 0x00, 0x00]);
+    expect(detect(unknownSignature)).toBeNull();
+  });
+
+  Object.keys(FILE_SIGNATURES).forEach((key) => {
+    const mimeType = key as MimeType;
+
+    test(`should detect ${mimeType} files`, () => {
+      const signatureBuffer = Buffer.from(FILE_SIGNATURES[mimeType]);
+      expect(detect(signatureBuffer)).toEqual(MIME_TYPES[mimeType]);
+    });
+  });
+
+  test("should return null for partial signatures", () => {
+    const partialJPEGSignature = Buffer.from([0xff, 0xd8]);
+    expect(detect(partialJPEGSignature)).toBeNull();
+  });
+
+  test("should detect MIME type even with extra data", () => {
+    const jpegWithExtraData = Buffer.concat([
+      Buffer.from(FILE_SIGNATURES.JPEG),
+      Buffer.from([0x00, 0x01, 0x02]),
+    ]);
+    expect(detect(jpegWithExtraData)).toEqual(MIME_TYPES.JPEG);
+  });
+});

--- a/packages/image/src/__test__/detect.test.ts
+++ b/packages/image/src/__test__/detect.test.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "buffer";
 import { describe, expect, test } from "vitest";
-import { FILE_SIGNATURES, MIME_TYPES, type MimeType, detect } from "..";
+import { detect } from "..";
+import { FILE_SIGNATURES, MIME_TYPES, type MimeType } from "../detect";
 
 describe("MIME type detection utility", () => {
   test("should return null for unknown signatures", () => {

--- a/packages/image/src/detect.ts
+++ b/packages/image/src/detect.ts
@@ -31,7 +31,7 @@ export const FILE_TYPES = {
     mime: "image/x-icon",
     signature: [0x00, 0x00, 0x01, 0x00],
   },
-} as const;
+};
 
 const FILE_TYPE_KEYS = Object.keys(
   FILE_TYPES,
@@ -44,7 +44,7 @@ const FILE_TYPE_KEYS = Object.keys(
  * @param {Buffer} buffer - The buffer containing the file's first few bytes.
  * @returns The detected MIME type or null if no known signature is matched.
  */
-export function detect(buffer: Buffer): string | null {
+export function detect(buffer: Buffer) {
   for (const key of FILE_TYPE_KEYS) {
     const { mime, signature } = FILE_TYPES[key];
 

--- a/packages/image/src/detect.ts
+++ b/packages/image/src/detect.ts
@@ -1,0 +1,52 @@
+export const MIME_TYPES = {
+  JPEG: "image/jpeg",
+  PNG: "image/png",
+  GIF: "image/gif",
+  WEBP: "image/webp",
+  SVG: "image/svg+xml",
+  AVIF: "image/avif",
+  ICO: "image/x-icon",
+} as const;
+
+export type MimeType = keyof typeof MIME_TYPES;
+
+/**
+ * Represents the file signatures for various MIME types.
+ * @see https://en.wikipedia.org/wiki/List_of_file_signatures
+ */
+export const FILE_SIGNATURES: Record<MimeType, number[]> = {
+  JPEG: [0xff, 0xd8, 0xff],
+  PNG: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+  GIF: [0x47, 0x49, 0x46, 0x38],
+  WEBP: [0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50],
+  SVG: [0x3c, 0x3f, 0x78, 0x6d, 0x6c],
+  AVIF: [0, 0, 0, 0, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66],
+  ICO: [0x00, 0x00, 0x01, 0x00],
+};
+
+function isMimeType(value: string): value is MimeType {
+  return value in MIME_TYPES;
+}
+
+/**
+ * Inspects the first few bytes of a buffer to determine if
+ * it matches a known file signature.
+ *
+ * @param {Buffer} buffer - The buffer containing the file's first few bytes.
+ * @returns {(typeof MIME_TYPES)[MimeType] | null} - The detected MIME type or null if no known signature is matched.
+ */
+export function detect(buffer: Buffer): (typeof MIME_TYPES)[MimeType] | null {
+  for (const mimeType in FILE_SIGNATURES) {
+    if (isMimeType(mimeType)) {
+      const matchesSignature = FILE_SIGNATURES[mimeType].every(
+        (b, i) => !b || buffer[i] === b,
+      );
+
+      if (matchesSignature) {
+        return MIME_TYPES[mimeType];
+      }
+    }
+  }
+
+  return null;
+}

--- a/packages/image/src/detect.ts
+++ b/packages/image/src/detect.ts
@@ -1,50 +1,55 @@
-export const MIME_TYPES = {
-  JPEG: "image/jpeg",
-  PNG: "image/png",
-  GIF: "image/gif",
-  WEBP: "image/webp",
-  SVG: "image/svg+xml",
-  AVIF: "image/avif",
-  ICO: "image/x-icon",
-} as const;
-
-export type MimeType = keyof typeof MIME_TYPES;
-
 /**
  * Represents the file signatures for various MIME types.
  * @see https://en.wikipedia.org/wiki/List_of_file_signatures
  */
-export const FILE_SIGNATURES: Record<MimeType, number[]> = {
-  JPEG: [0xff, 0xd8, 0xff],
-  PNG: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
-  GIF: [0x47, 0x49, 0x46, 0x38],
-  WEBP: [0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50],
-  SVG: [0x3c, 0x3f, 0x78, 0x6d, 0x6c],
-  AVIF: [0, 0, 0, 0, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66],
-  ICO: [0x00, 0x00, 0x01, 0x00],
-};
+export const FILE_TYPES = {
+  JPEG: {
+    mime: "image/jpeg",
+    signature: [0xff, 0xd8, 0xff],
+  },
+  PNG: {
+    mime: "image/png",
+    signature: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+  },
+  GIF: {
+    mime: "image/gif",
+    signature: [0x47, 0x49, 0x46, 0x38],
+  },
+  WEBP: {
+    mime: "image/webp",
+    signature: [0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50],
+  },
+  SVG: {
+    mime: "image/svg+xml",
+    signature: [0x3c, 0x3f, 0x78, 0x6d, 0x6c],
+  },
+  AVIF: {
+    mime: "image/avif",
+    signature: [0, 0, 0, 0, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66],
+  },
+  ICO: {
+    mime: "image/x-icon",
+    signature: [0x00, 0x00, 0x01, 0x00],
+  },
+} as const;
 
-function isMimeType(value: string): value is MimeType {
-  return value in MIME_TYPES;
-}
+const FILE_TYPE_KEYS = Object.keys(
+  FILE_TYPES,
+) as readonly (keyof typeof FILE_TYPES)[];
 
 /**
  * Inspects the first few bytes of a buffer to determine if
  * it matches a known file signature.
  *
  * @param {Buffer} buffer - The buffer containing the file's first few bytes.
- * @returns {(typeof MIME_TYPES)[MimeType] | null} - The detected MIME type or null if no known signature is matched.
+ * @returns The detected MIME type or null if no known signature is matched.
  */
-export function detect(buffer: Buffer): (typeof MIME_TYPES)[MimeType] | null {
-  for (const mimeType in FILE_SIGNATURES) {
-    if (isMimeType(mimeType)) {
-      const matchesSignature = FILE_SIGNATURES[mimeType].every(
-        (b, i) => !b || buffer[i] === b,
-      );
+export function detect(buffer: Buffer): string | null {
+  for (const key of FILE_TYPE_KEYS) {
+    const { mime, signature } = FILE_TYPES[key];
 
-      if (matchesSignature) {
-        return MIME_TYPES[mimeType];
-      }
+    if (signature.every((byte, index) => byte === buffer[index])) {
+      return mime;
     }
   }
 

--- a/packages/image/src/index.ts
+++ b/packages/image/src/index.ts
@@ -1,3 +1,3 @@
 export { default as checkWebPSupport } from "./checkWebPSupport";
-export { FILE_SIGNATURES, MIME_TYPES, detect, type MimeType } from "./detect";
+export { detect } from "./detect";
 export { load, type ImageSource } from "./load";

--- a/packages/image/src/index.ts
+++ b/packages/image/src/index.ts
@@ -1,2 +1,3 @@
 export { default as checkWebPSupport } from "./checkWebPSupport";
+export { FILE_SIGNATURES, MIME_TYPES, detect, type MimeType } from "./detect";
 export { load, type ImageSource } from "./load";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 5.0.1
       turbo:
         specifier: latest
-        version: 1.10.13
+        version: 1.10.14
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -112,6 +112,9 @@ importers:
       '@fepack/tsconfig':
         specifier: workspace:*
         version: link:../../configs/tsconfig
+      '@types/node':
+        specifier: ^20.6.2
+        version: 20.6.2
       '@vitest/browser':
         specifier: ^0.34.4
         version: 0.34.4(rollup@2.79.1)(vitest@0.34.4)
@@ -3795,6 +3798,10 @@ packages:
   /@types/node@18.17.16:
     resolution: {integrity: sha512-e0zgs7qe1XH/X3KEPnldfkD07LH9O1B9T31U8qoO7lqGSjj3/IrBuvqMeJ1aYejXRK3KOphIUDw6pLIplEW17A==}
 
+  /@types/node@20.6.2:
+    resolution: {integrity: sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw==}
+    dev: true
+
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
     dev: true
@@ -3869,7 +3876,7 @@ packages:
   /@types/sax@1.2.4:
     resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.17.16
     dev: false
 
   /@types/scheduler@0.16.3:
@@ -11618,64 +11625,64 @@ packages:
       yargs: 17.7.2
     dev: true
 
-  /turbo-darwin-64@1.10.13:
-    resolution: {integrity: sha512-vmngGfa2dlYvX7UFVncsNDMuT4X2KPyPJ2Jj+xvf5nvQnZR/3IeDEGleGVuMi/hRzdinoxwXqgk9flEmAYp0Xw==}
+  /turbo-darwin-64@1.10.14:
+    resolution: {integrity: sha512-I8RtFk1b9UILAExPdG/XRgGQz95nmXPE7OiGb6ytjtNIR5/UZBS/xVX/7HYpCdmfriKdVwBKhalCoV4oDvAGEg==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64@1.10.13:
-    resolution: {integrity: sha512-eMoJC+k7gIS4i2qL6rKmrIQGP6Wr9nN4odzzgHFngLTMimok2cGLK3qbJs5O5F/XAtEeRAmuxeRnzQwTl/iuAw==}
+  /turbo-darwin-arm64@1.10.14:
+    resolution: {integrity: sha512-KAdUWryJi/XX7OD0alOuOa0aJ5TLyd4DNIYkHPHYcM6/d7YAovYvxRNwmx9iv6Vx6IkzTnLeTiUB8zy69QkG9Q==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64@1.10.13:
-    resolution: {integrity: sha512-0CyYmnKTs6kcx7+JRH3nPEqCnzWduM0hj8GP/aodhaIkLNSAGAa+RiYZz6C7IXN+xUVh5rrWTnU2f1SkIy7Gdg==}
+  /turbo-linux-64@1.10.14:
+    resolution: {integrity: sha512-BOBzoREC2u4Vgpap/WDxM6wETVqVMRcM8OZw4hWzqCj2bqbQ6L0wxs1LCLWVrghQf93JBQtIGAdFFLyCSBXjWQ==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64@1.10.13:
-    resolution: {integrity: sha512-0iBKviSGQQlh2OjZgBsGjkPXoxvRIxrrLLbLObwJo3sOjIH0loGmVIimGS5E323soMfi/o+sidjk2wU1kFfD7Q==}
+  /turbo-linux-arm64@1.10.14:
+    resolution: {integrity: sha512-D8T6XxoTdN5D4V5qE2VZG+/lbZX/89BkAEHzXcsSUTRjrwfMepT3d2z8aT6hxv4yu8EDdooZq/2Bn/vjMI32xw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64@1.10.13:
-    resolution: {integrity: sha512-S5XySRfW2AmnTeY1IT+Jdr6Goq7mxWganVFfrmqU+qqq3Om/nr0GkcUX+KTIo9mPrN0D3p5QViBRzulwB5iuUQ==}
+  /turbo-windows-64@1.10.14:
+    resolution: {integrity: sha512-zKNS3c1w4i6432N0cexZ20r/aIhV62g69opUn82FLVs/zk3Ie0GVkSB6h0rqIvMalCp7enIR87LkPSDGz9K4UA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64@1.10.13:
-    resolution: {integrity: sha512-nKol6+CyiExJIuoIc3exUQPIBjP9nIq5SkMJgJuxsot2hkgGrafAg/izVDRDrRduQcXj2s8LdtxJHvvnbI8hEQ==}
+  /turbo-windows-arm64@1.10.14:
+    resolution: {integrity: sha512-rkBwrTPTxNSOUF7of8eVvvM+BkfkhA2OvpHM94if8tVsU+khrjglilp8MTVPHlyS9byfemPAmFN90oRIPB05BA==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo@1.10.13:
-    resolution: {integrity: sha512-vOF5IPytgQPIsgGtT0n2uGZizR2N3kKuPIn4b5p5DdeLoI0BV7uNiydT7eSzdkPRpdXNnO8UwS658VaI4+YSzQ==}
+  /turbo@1.10.14:
+    resolution: {integrity: sha512-hr9wDNYcsee+vLkCDIm8qTtwhJ6+UAMJc3nIY6+PNgUTtXcQgHxCq8BGoL7gbABvNWv76CNbK5qL4Lp9G3ZYRA==}
     hasBin: true
     optionalDependencies:
-      turbo-darwin-64: 1.10.13
-      turbo-darwin-arm64: 1.10.13
-      turbo-linux-64: 1.10.13
-      turbo-linux-arm64: 1.10.13
-      turbo-windows-64: 1.10.13
-      turbo-windows-arm64: 1.10.13
+      turbo-darwin-64: 1.10.14
+      turbo-darwin-arm64: 1.10.14
+      turbo-linux-64: 1.10.14
+      turbo-linux-arm64: 1.10.14
+      turbo-windows-64: 1.10.14
+      turbo-windows-arm64: 1.10.14
     dev: true
 
   /typanion@3.14.0:


### PR DESCRIPTION
## Summary
- Integrated a MIME type detection utility in the `fepack/image` package. This enhancement will allow users to easily identify and work with various image formats.
- Being able to reliably determine the MIME type of an image ensures better compatibility and error handling. potentially eliminating a number of runtime errors.

<!-- Please summarize your changes. -->

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

<!-- For completed items, change [ ] to [x]. -->

<!-- If you leave this checklist empty, your PR will very likely be closed. -->

Please check the following:

- [x] I have written documents and tests, if needed.
