### PR TITLE
refactor: remove duplicate packages and refine return types

### DIFF
--- a/.changeset/slimy-buttons-beam.md
+++ b/.changeset/slimy-buttons-beam.md
@@ -1,0 +1,5 @@
+---
+"@fepack/image": patch
+---
+
+refactor: remove duplicate packages and refine return types

--- a/configs/eslint-config-ts/package.json
+++ b/configs/eslint-config-ts/package.json
@@ -13,10 +13,7 @@
     "@fepack/eslint-config-js": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-import-resolver-typescript": "^2.5.0",
-    "eslint-plugin-import": "^2.25.3",
-    "eslint-plugin-prettier": "^4.2.1"
+    "eslint-import-resolver-typescript": "^2.5.0"
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/configs/eslint-config/package.json
+++ b/configs/eslint-config/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@fepack/eslint-config-js": "workspace:*",
     "@fepack/eslint-config-ts": "workspace:*",
-    "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0"
   },

--- a/packages/image/src/checkWebPSupport.ts
+++ b/packages/image/src/checkWebPSupport.ts
@@ -16,10 +16,9 @@ type Feature = keyof typeof kTestImages;
 /**
  * Checks if a specific WebP feature is supported by the browser.
  * @param feature - The WebP feature to check for.
- * @returns {Promise<boolean>} Returns a promise that resolves with a boolean indicating if the specified WebP feature is supported.
  */
-async function checkWebPFeatureSupport(feature: Feature): Promise<boolean> {
-  return new Promise((resolve) => {
+function checkWebPFeatureSupport(feature: Feature) {
+  return new Promise<boolean>((resolve) => {
     const image = new Image();
     image.onload = () => resolve(image.width > 0 && image.height > 0);
     image.onerror = () => resolve(false);
@@ -33,9 +32,8 @@ const features = Object.keys(kTestImages).filter((key): key is Feature =>
 
 /**
  * Checks if the browser supports all key WebP features.
- * @returns {Promise<boolean>} Returns a promise that resolves with a boolean indicating if all key WebP features are supported.
  */
-async function checkWebPSupport(): Promise<boolean> {
+async function checkWebPSupport() {
   const results = await Promise.all(features.map(checkWebPFeatureSupport));
   return results.every(Boolean);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -40,9 +44,6 @@ importers:
       eslint:
         specifier: ^6.0.0 || ^7.0.0 || ^8.0.0
         version: 7.32.0
-      eslint-plugin-import:
-        specifier: ^2.25.3
-        version: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.0)(eslint@7.32.0)
       eslint-plugin-react:
         specifier: ^7.32.2
         version: 7.33.2(eslint@7.32.0)
@@ -82,18 +83,9 @@ importers:
       eslint:
         specifier: ^6.0.0 || ^7.0.0 || ^8.0.0
         version: 7.32.0
-      eslint-config-prettier:
-        specifier: ^8.3.0
-        version: 8.10.0(eslint@7.32.0)
       eslint-import-resolver-typescript:
         specifier: ^2.5.0
         version: 2.7.1(eslint-plugin-import@2.28.1)(eslint@7.32.0)
-      eslint-plugin-import:
-        specifier: ^2.25.3
-        version: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
-      eslint-plugin-prettier:
-        specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.10.0)(eslint@7.32.0)(prettier@2.8.8)
 
   configs/tsconfig: {}
 
@@ -12747,7 +12739,3 @@ packages:
   /zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Summary

1. Removing duplicated package dependencies across the project to optimize package installation and maintainability.
  - As a result, removed overlapping dependencies (`eslint-config-prettier`, `eslint-plugin-import`, `eslint-plugin-prettier`) that are already included in `@fepack/eslint-config-js`.
2. Refining the functions by removing explicit return types where they can be implicitly inferred, leading to cleaner code. The refinement is based on the best practices highlighted in [this video](https://youtu.be/I6V2FkW1ozQ?feature=shared).


<!-- Please summarize your changes. -->

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

<!-- For completed items, change [ ] to [x]. -->

<!-- If you leave this checklist empty, your PR will very likely be closed. -->

Please check the following:

- [x] I have written documents and tests, if needed.
