### PR TITLE
feat(image, react-image): add `LoadClient`, update `load` can return image, export all public apis of @fepack/image in @fepack/react-image

### DIFF
--- a/.changeset/brave-timers-lick.md
+++ b/.changeset/brave-timers-lick.md
@@ -1,0 +1,6 @@
+---
+"@fepack/image": minor
+"@fepack/react-image": minor
+---
+
+feat(image): add load to return image

--- a/.changeset/brave-timers-lick.md
+++ b/.changeset/brave-timers-lick.md
@@ -3,4 +3,4 @@
 "@fepack/react-image": minor
 ---
 
-feat(image): add load to return image
+feat(image): add `LoadClient`, update `load` can return image, export all public apis of @fepack/image in @fepack/react-image

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": ["@fepack/image", "@fepack/react-image"],
+  "fixed": [["@fepack/image", "@fepack/react-image"]],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": ["@fepack/image", "@fepack/react-image"],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",

--- a/packages/image/.eslintrc.cjs
+++ b/packages/image/.eslintrc.cjs
@@ -1,9 +1,6 @@
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
   root: true,
-  extends: [
-    "@fepack/eslint-config-ts/typescript",
-    "@fepack/eslint-config-js/javascript",
-  ],
+  extends: ["@fepack/eslint-config-ts"],
   ignorePatterns: ["*.js*", "dist", "coverage"],
 };

--- a/packages/image/src/LoadClient.ts
+++ b/packages/image/src/LoadClient.ts
@@ -1,0 +1,65 @@
+import { load } from "./load";
+
+export type LoadSrc = Parameters<typeof load>[0];
+
+export type LoadState<TLoadSrc extends LoadSrc> = {
+  src: TLoadSrc;
+  promise?: Promise<unknown>;
+  error?: unknown;
+};
+
+type Notify = (...args: unknown[]) => unknown;
+export class LoadClient {
+  private loadCache = new Map<LoadSrc, LoadState<LoadSrc>>();
+  private notifiesMap = new Map<LoadSrc, Notify[]>();
+
+  attach(src: LoadSrc, notify: Notify) {
+    const notifies = this.notifiesMap.get(src);
+    this.notifiesMap.set(src, [...(notifies ?? []), notify]);
+
+    return {
+      detach: () => this.detach(src, notify),
+    };
+  }
+
+  detach(src: LoadSrc, notify: Notify) {
+    const notifies = this.notifiesMap.get(src);
+    if (notifies) {
+      this.notifiesMap.set(
+        src,
+        notifies.filter((item) => item !== notify),
+      );
+    }
+  }
+
+  load<TLoadSrc extends LoadSrc>(src: TLoadSrc) {
+    const loadState = this.loadCache.get(src);
+
+    if (loadState?.error) {
+      throw loadState.error;
+    }
+    if (loadState?.src) {
+      return loadState as LoadState<TLoadSrc>;
+    }
+    if (loadState?.promise) {
+      throw loadState.promise;
+    }
+
+    const newLoadState: LoadState<TLoadSrc> = {
+      src,
+      promise: load(src)
+        .then((image) => (newLoadState.src = image.src as TLoadSrc))
+        .catch(() => (newLoadState.error = `${src}: load error`)),
+    };
+
+    this.loadCache.set(src, newLoadState);
+    throw newLoadState.promise;
+  }
+
+  private notify(src: LoadSrc) {
+    const notifies = this.notifiesMap.get(src);
+    if (notifies) {
+      for (const notify of notifies) notify();
+    }
+  }
+}

--- a/packages/image/src/extractRGBAs.spec.ts
+++ b/packages/image/src/extractRGBAs.spec.ts
@@ -1,13 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractRGBAs } from ".";
-
-const load = (src: HTMLImageElement["src"]) =>
-  new Promise<HTMLImageElement>((resolve, reject) => {
-    const image = new Image();
-    image.onload = () => resolve(image);
-    image.onerror = () => reject();
-    image.src = src;
-  });
+import { extractRGBAs, load } from ".";
 
 describe("extractRGBAs", () => {
   it("should return an array of colors", async () => {

--- a/packages/image/src/index.ts
+++ b/packages/image/src/index.ts
@@ -2,3 +2,6 @@ export { checkWebPSupport } from "./checkWebPSupport";
 export { detect } from "./detect";
 export { extractRGBAs } from "./extractRGBAs";
 export { load } from "./load";
+export { LoadClient } from "./LoadClient";
+
+export type { LoadSrc, LoadState } from "./LoadClient";

--- a/packages/image/src/index.ts
+++ b/packages/image/src/index.ts
@@ -1,4 +1,4 @@
 export { checkWebPSupport } from "./checkWebPSupport";
 export { detect } from "./detect";
 export { extractRGBAs } from "./extractRGBAs";
-export { load, type ImageSource } from "./load";
+export { load } from "./load";

--- a/packages/image/src/load.spec.ts
+++ b/packages/image/src/load.spec.ts
@@ -1,49 +1,9 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { load } from ".";
 
-class MockImage {
-  public src = "";
-
-  public setAttribute(name: string, value: string) {
-    this[name] = value;
-  }
-
-  public constructor() {
-    MockImage.lastInstance = this;
-  }
-
-  public static lastInstance: MockImage;
-}
-
 describe("load", () => {
-  const originalImage = window.Image;
-
-  beforeAll(() => {
-    window.Image = MockImage as unknown as typeof Image;
-  });
-
-  afterAll(() => {
-    window.Image = originalImage;
-  });
-
-  it("should load defaultSrc when webpSrc is not provided", () => {
-    load([
-      {
-        defaultSrc: "./images/test.png",
-      },
-    ]);
-
-    expect(MockImage.lastInstance.src).toBe("./images/test.png");
-  });
-
-  it("should load webpSrc when provided", () => {
-    load([
-      {
-        defaultSrc: "./images/test.png",
-        webpSrc: "./images/test.webp",
-      },
-    ]);
-
-    expect(MockImage.lastInstance.src).toBe("./images/test.webp");
+  it("should load image by src", async () => {
+    const loadedImage = await load("src/images/test.png");
+    expect(loadedImage.src).toBe("http://localhost:5173/src/images/test.png");
   });
 });

--- a/packages/image/src/load.ts
+++ b/packages/image/src/load.ts
@@ -1,15 +1,10 @@
-export interface ImageSource {
-  defaultSrc: string;
-  webpSrc?: string;
-}
-
 /**
  * Loads the given images. If WebP is WebP source is provided, it will load that. Otherwise, it loads the default source.
- * @param {ImageSource[]} images - Array of image sources to preload.
  */
-export const load = (images: ImageSource[]) => {
-  for (const image of images) {
-    const imageElement = new Image();
-    imageElement.src = image.webpSrc ? image.webpSrc : image.defaultSrc;
-  }
-};
+export const load = (src: HTMLImageElement["src"]) =>
+  new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject();
+    image.src = src;
+  });

--- a/packages/image/src/load.ts
+++ b/packages/image/src/load.ts
@@ -1,5 +1,5 @@
 /**
- * Loads the given images. If WebP is WebP source is provided, it will load that. Otherwise, it loads the default source.
+ * Loads an image from the given source URL and returns a Promise that resolves to the loaded image.
  */
 export const load = (src: HTMLImageElement["src"]) =>
   new Promise<HTMLImageElement>((resolve, reject) => {

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -36,9 +36,11 @@
     "prepack": "pnpm build",
     "type:check": "tsc --noEmit"
   },
+  "dependencies": {
+    "@fepack/image": "workspace:*"
+  },
   "devDependencies": {
     "@fepack/eslint-config": "workspace:^",
-    "@fepack/image": "workspace:*",
     "@fepack/tsconfig": "workspace:*",
     "@types/node": "^18.16.2",
     "@types/react": "^18.2.0",

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -2,6 +2,10 @@
   "name": "@fepack/react-image",
   "version": "0.0.2",
   "license": "MIT",
+  "author": {
+    "name": "Jonghyeon Ko",
+    "email": "manudeli.ko@gmail.com"
+  },
   "sideEffects": false,
   "type": "module",
   "exports": {
@@ -23,10 +27,6 @@
     "dist",
     "src"
   ],
-  "author": {
-    "name": "Jonghyeon Ko",
-    "email": "manudeli.ko@gmail.com"
-  },
   "scripts": {
     "build": "tsup",
     "build:watch": "tsup --watch",
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@fepack/eslint-config": "workspace:^",
+    "@fepack/image": "workspace:*",
     "@fepack/tsconfig": "workspace:*",
     "@types/node": "^18.16.2",
     "@types/react": "^18.2.0",

--- a/packages/react-image/src/Load.ts
+++ b/packages/react-image/src/Load.ts
@@ -1,80 +1,29 @@
-import { load } from "@fepack/image";
-import type { FunctionComponent } from "react";
-import { createElement, useSyncExternalStore } from "react";
+import { LoadClient, type LoadSrc, type LoadState } from "@fepack/image";
+import {
+  type FunctionComponent,
+  createElement,
+  useSyncExternalStore,
+} from "react";
 
-type Src = Parameters<typeof load>[0];
-type LoadOptions<TSrc extends Src> = { src: TSrc };
-type Notify = (...args: unknown[]) => unknown;
+const loadClient = new LoadClient();
 
-const loadCache = new Map<Src, LoadState>();
-const loadClient = new (class LoadClient {
-  private notifiesMap = new Map<Src, Notify[]>();
-
-  public attach<TSrc extends Src>(src: TSrc, onNotify: Notify) {
-    const srcNotifies = this.notifiesMap.get(src);
-    this.notifiesMap.set(src, [...(srcNotifies ?? []), onNotify]);
-
-    const attached = {
-      detach: () => this.detach(src, onNotify),
-    };
-
-    return attached;
-  }
-
-  public detach<TSrc extends Src>(src: TSrc, onNotify: Notify) {
-    const srcNotifies = this.notifiesMap.get(src);
-
-    if (srcNotifies) {
-      this.notifiesMap.set(
-        src,
-        srcNotifies.filter((notify) => notify !== onNotify),
-      );
-    }
-  }
-
-  public _load = <TSrc extends Src>(src: TSrc): LoadState<TSrc> => {
-    const loadState = loadCache.get(src);
-    if (loadState?.error) {
-      throw loadState.error;
-    }
-    if (loadState?.src) {
-      return loadState as LoadState<TSrc>;
-    }
-    if (loadState?.promise) {
-      throw loadState.promise;
-    }
-
-    const newLoadState: LoadState<TSrc> = {
-      src,
-      promise: load(src)
-        .then((image) => (newLoadState.src = image.src as TSrc))
-        .catch(() => (newLoadState.error = `${src}: load error`)),
-    };
-    loadCache.set(src, newLoadState);
-    throw newLoadState.promise;
-  };
-})();
-
-type UseLoadOptions<TSrc extends Src> = {
-  src: TSrc;
+type UseLoadOptions<TLoadSrc extends LoadSrc> = {
+  src: TLoadSrc;
 };
-
-type LoadState<TSrc extends Src = Src> = UseLoadOptions<TSrc> & {
-  promise?: Promise<unknown>;
-  error?: unknown;
-};
-
-export const useLoad = <TSrc extends Src>(
-  options: UseLoadOptions<TSrc>,
-): LoadState<TSrc> =>
+export const useLoad = <TLoadSrc extends LoadSrc>(
+  options: UseLoadOptions<TLoadSrc>,
+) =>
   useSyncExternalStore(
     (onStoreChange) => loadClient.attach(options.src, onStoreChange).detach,
-    () => loadClient._load<TSrc>(options.src),
-    () => loadClient._load<TSrc>(options.src),
+    () => loadClient.load<TLoadSrc>(options.src),
+    () => loadClient.load<TLoadSrc>(options.src),
   );
 
-type LoadProps<TSrc extends Src> = LoadOptions<TSrc> & {
-  children: FunctionComponent<LoadState<TSrc>>;
+type LoadProps<TLoadSrc extends LoadSrc> = {
+  src: TLoadSrc;
+  children: FunctionComponent<LoadState<TLoadSrc>>;
 };
-export const Load = <TSrc extends Src>({ src, children }: LoadProps<TSrc>) =>
-  createElement(children, useLoad({ src }));
+export const Load = <TLoadSrc extends LoadSrc>({
+  src,
+  children,
+}: LoadProps<TLoadSrc>) => createElement(children, useLoad({ src }));

--- a/packages/react-image/src/Load.ts
+++ b/packages/react-image/src/Load.ts
@@ -32,7 +32,7 @@ const loadClient = new (class LoadClient {
     }
   }
 
-  public _load = <TSrc extends Src>(src: TSrc): { src: TSrc } => {
+  public _load = <TSrc extends Src>(src: TSrc):  LoadState<TSrc> => {
     const loadStateGot = loadCache.get(src);
     if (loadStateGot?.error) {
       throw loadStateGot.error;

--- a/packages/react-image/src/Load.ts
+++ b/packages/react-image/src/Load.ts
@@ -34,14 +34,12 @@ const loadClient = new (class LoadClient {
 
   public _load = <TSrc extends Src>(src: TSrc): { src: TSrc } => {
     const loadStateGot = loadCache.get(src);
-
     if (loadStateGot?.error) {
       throw loadStateGot.error;
     }
     if (loadStateGot?.src) {
       return loadStateGot as LoadState<TSrc>;
     }
-
     if (loadStateGot?.promise) {
       throw loadStateGot.promise;
     }
@@ -52,7 +50,6 @@ const loadClient = new (class LoadClient {
         .then((image) => (newLoadState.src = image.src as TSrc))
         .catch(() => (newLoadState.error = `${src}: load error`)),
     };
-
     loadCache.set(src, newLoadState);
     throw newLoadState.promise;
   };

--- a/packages/react-image/src/Load.ts
+++ b/packages/react-image/src/Load.ts
@@ -33,15 +33,15 @@ const loadClient = new (class LoadClient {
   }
 
   public _load = <TSrc extends Src>(src: TSrc): LoadState<TSrc> => {
-    const loadStateGot = loadCache.get(src);
-    if (loadStateGot?.error) {
-      throw loadStateGot.error;
+    const loadState = loadCache.get(src);
+    if (loadState?.error) {
+      throw loadState.error;
     }
-    if (loadStateGot?.src) {
-      return loadStateGot as LoadState<TSrc>;
+    if (loadState?.src) {
+      return loadState as LoadState<TSrc>;
     }
-    if (loadStateGot?.promise) {
-      throw loadStateGot.promise;
+    if (loadState?.promise) {
+      throw loadState.promise;
     }
 
     const newLoadState: LoadState<TSrc> = {

--- a/packages/react-image/src/Load.ts
+++ b/packages/react-image/src/Load.ts
@@ -32,7 +32,7 @@ const loadClient = new (class LoadClient {
     }
   }
 
-  public _load = <TSrc extends Src>(src: TSrc):  LoadState<TSrc> => {
+  public _load = <TSrc extends Src>(src: TSrc): LoadState<TSrc> => {
     const loadStateGot = loadCache.get(src);
     if (loadStateGot?.error) {
       throw loadStateGot.error;

--- a/packages/react-image/src/index.ts
+++ b/packages/react-image/src/index.ts
@@ -1,1 +1,3 @@
+export * from "@fepack/image";
+
 export { Load, useLoad } from "./Load";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,13 +125,14 @@ importers:
         version: 0.34.4(@vitest/browser@0.34.4)(jsdom@22.1.0)(playwright@1.38.0)
 
   packages/react-image:
+    dependencies:
+      '@fepack/image':
+        specifier: workspace:*
+        version: link:../image
     devDependencies:
       '@fepack/eslint-config':
         specifier: workspace:^
         version: link:../../configs/eslint-config
-      '@fepack/image':
-        specifier: workspace:*
-        version: link:../image
       '@fepack/tsconfig':
         specifier: workspace:*
         version: link:../../configs/tsconfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -125,6 +129,9 @@ importers:
       '@fepack/eslint-config':
         specifier: workspace:^
         version: link:../../configs/eslint-config
+      '@fepack/image':
+        specifier: workspace:*
+        version: link:../image
       '@fepack/tsconfig':
         specifier: workspace:*
         version: link:../../configs/tsconfig
@@ -12890,7 +12897,3 @@ packages:
   /zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,7 @@
     "lint:pub": { "cache": false },
     "prepack": {
       "outputs": ["dist/**"],
+      "dependsOn": ["^prepack"],
       "cache": false
     },
     "test": {

--- a/websites/demo-image/src/main.ts
+++ b/websites/demo-image/src/main.ts
@@ -1,20 +1,9 @@
 import { checkWebPSupport, load } from "@fepack/image";
 
-const images = [
-  { defaultSrc: "/options_resize.png" },
-  {
-    webpSrc: "/information_resize.webp",
-    defaultSrc: "/information_resize.png",
-  },
-];
-
-(async function () {
-  const webPSupport = await checkWebPSupport();
-
-  console.log(webPSupport);
-})();
-
-load(images);
+checkWebPSupport().then(console.log);
+load("/options_resize.png");
+load("/information_resize.webp");
+load("/information_resize.png");
 
 (document.querySelector<HTMLDivElement>("#app") as HTMLDivElement).innerHTML = `
   <div>

--- a/websites/demo-react-image-next/package.json
+++ b/websites/demo-react-image-next/package.json
@@ -12,12 +12,12 @@
   "dependencies": {
     "@emotion/react": "^11.10.8",
     "@emotion/styled": "^11.10.8",
+    "@fepack/react-image": "workspace:0.0.2",
     "@jsxcss/emotion": "^1.3.9",
     "@suspensive/react": "1.14.1",
     "next": "^13.4.4",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "@fepack/react-image": "workspace:0.0.2"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@fepack/eslint-config": "workspace:*",

--- a/websites/demo-react-image-next/src/app/load/page.tsx
+++ b/websites/demo-react-image-next/src/app/load/page.tsx
@@ -5,19 +5,17 @@ import { Suspense } from "@suspensive/react";
 import Link from "next/link";
 import { Area } from "~/components/uis";
 
-const BoundaryPage = () => {
-  return (
-    <div>
-      <Link href="/">to home</Link>
-      <Area title="Load">
-        <Suspense.CSROnly>
-          <Load src="https://ik.imagekit.io/ikmedia/women-dress-2.jpg">
-            {(loaded) => <img src={loaded.src} />}
-          </Load>
-        </Suspense.CSROnly>
-      </Area>
-    </div>
-  );
-};
+const BoundaryPage = () => (
+  <div>
+    <Link href="/">to home</Link>
+    <Area title="Load">
+      <Suspense.CSROnly>
+        <Load src="https://ik.imagekit.io/ikmedia/women-dress-2.jpg">
+          {(loaded) => <img src={loaded.src} />}
+        </Load>
+      </Suspense.CSROnly>
+    </Area>
+  </div>
+);
 
 export default BoundaryPage;

--- a/websites/demo-react-image-next/src/app/load/page.tsx
+++ b/websites/demo-react-image-next/src/app/load/page.tsx
@@ -3,14 +3,15 @@
 import { Load } from "@fepack/react-image";
 import { Suspense } from "@suspensive/react";
 import Link from "next/link";
-import { Area } from "~/components/uis";
+import { Area, Spinner } from "~/components/uis";
 
 const BoundaryPage = () => (
   <div>
     <Link href="/">to home</Link>
     <Area title="Load">
-      <Suspense.CSROnly>
+      <Suspense.CSROnly fallback={<Spinner />}>
         <Load src="https://ik.imagekit.io/ikmedia/women-dress-2.jpg">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           {(loaded) => <img src={loaded.src} />}
         </Load>
       </Suspense.CSROnly>

--- a/websites/demo-react-image-next/src/app/load/page.tsx
+++ b/websites/demo-react-image-next/src/app/load/page.tsx
@@ -12,7 +12,6 @@ export default function Page() {
       <Area title="Load">
         <Suspense.CSROnly fallback={<Spinner />}>
           <Load src="https://ik.imagekit.io/ikmedia/women-dress-2.jpg">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
             {(loaded) => <img src={loaded.src} />}
           </Load>
         </Suspense.CSROnly>

--- a/websites/demo-react-image-next/src/app/load/page.tsx
+++ b/websites/demo-react-image-next/src/app/load/page.tsx
@@ -5,18 +5,18 @@ import { Suspense } from "@suspensive/react";
 import Link from "next/link";
 import { Area, Spinner } from "~/components/uis";
 
-const BoundaryPage = () => (
-  <div>
-    <Link href="/">to home</Link>
-    <Area title="Load">
-      <Suspense.CSROnly fallback={<Spinner />}>
-        <Load src="https://ik.imagekit.io/ikmedia/women-dress-2.jpg">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          {(loaded) => <img src={loaded.src} />}
-        </Load>
-      </Suspense.CSROnly>
-    </Area>
-  </div>
-);
-
-export default BoundaryPage;
+export default function Page() {
+  return (
+    <div>
+      <Link href="/">to home</Link>
+      <Area title="Load">
+        <Suspense.CSROnly fallback={<Spinner />}>
+          <Load src="https://ik.imagekit.io/ikmedia/women-dress-2.jpg">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            {(loaded) => <img src={loaded.src} />}
+          </Load>
+        </Suspense.CSROnly>
+      </Area>
+    </div>
+  );
+}

--- a/websites/demo-react-image-next/src/app/page.tsx
+++ b/websites/demo-react-image-next/src/app/page.tsx
@@ -3,21 +3,24 @@
 import { Load } from "@fepack/react-image";
 import { ErrorBoundary, Suspense } from "@suspensive/react";
 import Link from "next/link";
+import { Spinner } from "~/components/uis";
 
 export default function Home() {
   return (
     <div>
       <Link href="/load">to load</Link>
       <ErrorBoundary fallback={() => <>load image error</>}>
-        <Suspense.CSROnly>
+        <Suspense.CSROnly fallback={<Spinner />}>
           <Load src="https://ik.imagekit.io/ikmedia/women-dress-2.jpg">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
             {(loaded) => <img src={loaded.src} />}
           </Load>
         </Suspense.CSROnly>
       </ErrorBoundary>
       <ErrorBoundary fallback={() => <>load image error</>}>
-        <Suspense.CSROnly>
+        <Suspense.CSROnly fallback={<Spinner />}>
           <Load src="https://ik.imagekit.io/ikmedia/wome">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
             {(loaded) => <img src={loaded.src} />}
           </Load>
         </Suspense.CSROnly>

--- a/websites/demo-react-image-next/src/app/page.tsx
+++ b/websites/demo-react-image-next/src/app/page.tsx
@@ -12,7 +12,6 @@ export default function Home() {
       <ErrorBoundary fallback={() => <>load image error</>}>
         <Suspense.CSROnly fallback={<Spinner />}>
           <Load src="https://ik.imagekit.io/ikmedia/women-dress-2.jpg">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
             {(loaded) => <img src={loaded.src} />}
           </Load>
         </Suspense.CSROnly>
@@ -20,7 +19,6 @@ export default function Home() {
       <ErrorBoundary fallback={() => <>load image error</>}>
         <Suspense.CSROnly fallback={<Spinner />}>
           <Load src="https://ik.imagekit.io/ikmedia/wome">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
             {(loaded) => <img src={loaded.src} />}
           </Load>
         </Suspense.CSROnly>


### PR DESCRIPTION
fix #35

## Summary

<!-- Please summarize your changes. -->

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

1. I update `load` to make simply itself. and make @fepack/react-image use `load` of @fepack/image as dependency
2. I migrate `LoadClient` from @fepack/react-image into @fepack/image
3. I added @fepack/image as dependency and I also exported all public apis of @fepack/image in @fepack/react-image

## Checks

<!-- For completed items, change [ ] to [x]. -->

<!-- If you leave this checklist empty, your PR will very likely be closed. -->

Please check the following:

- [x] I have written documents and tests, if needed.
