### PR TITLE
fix(react-image): support under react 18

### DIFF
--- a/.changeset/selfish-pears-act.md
+++ b/.changeset/selfish-pears-act.md
@@ -1,0 +1,5 @@
+---
+"@fepack/react-image": patch
+---
+
+fix(react-image): support under react 18

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -47,7 +47,8 @@
     "type:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@fepack/image": "workspace:0.2.4"
+    "@fepack/image": "workspace:0.2.4",
+    "use-sync-external-store": "^1.2.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
@@ -56,6 +57,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.1",
     "@types/testing-library__jest-dom": "^5.14.5",
+    "@types/use-sync-external-store": "^0.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/react-image/src/Load.ts
+++ b/packages/react-image/src/Load.ts
@@ -1,9 +1,6 @@
 import { LoadClient, type LoadSrc, type LoadState } from "@fepack/image";
-import {
-  type FunctionComponent,
-  createElement,
-  useSyncExternalStore,
-} from "react";
+import { type FunctionComponent, createElement } from "react";
+import { useSyncExternalStore } from "use-sync-external-store/shim";
 
 const loadClient = new LoadClient();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@fepack/image':
         specifier: workspace:0.2.4
         version: link:../image
+      use-sync-external-store:
+        specifier: ^1.2.0
+        version: 1.2.0(react@18.2.0)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^5.16.5
@@ -157,6 +160,9 @@ importers:
       '@types/testing-library__jest-dom':
         specifier: ^5.14.5
         version: 5.14.9
+      '@types/use-sync-external-store':
+        specifier: ^0.0.4
+        version: 0.0.4
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -4045,6 +4051,10 @@ packages:
   /@types/unist@2.0.8:
     resolution: {integrity: sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==}
     dev: false
+
+  /@types/use-sync-external-store@0.0.4:
+    resolution: {integrity: sha512-DMBc2WDEfaGsWXqH/Sk2oBaUkvlUwqgt/YEygpqX0MaiEjqR7afd1QgE4Pq2zBr/TRz0Mpu92eBBo5UQjtTD5Q==}
+    dev: true
 
   /@types/ws@8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
@@ -12625,6 +12635,14 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 17.0.2
+    dev: false
+
+  /use-sync-external-store@1.2.0(react@18.2.0):
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /util-deprecate@1.0.2:


### PR DESCRIPTION
## Summary

We need to support react 16, 17 too. because we defined react 16, 17, not only 18 as peerDependencies
```json
"react": "^16.8 || ^17 || ^18"
```

Please check the following:

- [x] I have written documents and tests, if needed.
